### PR TITLE
Correct comment for HTML target

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -22,7 +22,7 @@ pub enum TargetType {
     Shell(bool, bool),
     /// Special Ansi/ans file that will always have colors enabled. Can also have background colors.
     AnsiFile(bool),
-    /// Shell target, Supports color and background colors.
+    /// HTML target, Supports color and background colors.
     HtmlFile(bool, bool),
     /// Every other file, does not support either colored outputs.
     File,


### PR DESCRIPTION
Target was documented as "Shell target", but since it's the "HTML target" I think this comment is incorrect.

Came across this while following [FasterThanLime's tutorial](https://fasterthanli.me/series/building-a-rust-service-with-nix/part-4), figured it'd be a nice microcontribution to fix.