### PR TITLE
Remove hardcoded Courier font family.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ dependencies = [
  "log",
  "minreq",
  "predicates 3.0.2",
+ "pretty_assertions",
  "terminal_size",
 ]
 
@@ -322,6 +323,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deflate"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +340,12 @@ checksum = "c86f7e25f518f4b81808a2cf1c50996a61f5c2eb394b2393bd87f2a4780a432f"
 dependencies = [
  "adler32",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "difflib"
@@ -822,6 +839,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,12 +956,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.36"
+name = "pretty_assertions"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
 dependencies = [
- "unicode-xid",
+ "ctor",
+ "diff",
+ "output_vt100",
+ "yansi",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -946,9 +984,9 @@ checksum = "e9e1dcb320d6839f6edb64f7a4a59d39b30480d4d1765b56873f7c858538a5fe"
 
 [[package]]
 name = "quote"
-version = "1.0.17"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -1101,13 +1139,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.90"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1172,10 +1210,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "unicode-ident"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "vcpkg"
@@ -1352,3 +1390,9 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ clap_mangen = "0.1.8"
 assert_cmd = "2.0.4"
 predicates = "3.0.2"
 criterion = "0.4.0"
+pretty_assertions = "1.3.0"
 
 [dependencies]
 image = "0.24.2"

--- a/assets/standard_test_img/standard_test_img.html
+++ b/assets/standard_test_img/standard_test_img.html
@@ -6,7 +6,6 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Artem Ascii Image</title>
-        <style>* {font-family: Courier;}</style>
     </head>
     
     <body>

--- a/assets/standard_test_img/standard_test_img_background.html
+++ b/assets/standard_test_img/standard_test_img_background.html
@@ -6,7 +6,6 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Artem Ascii Image</title>
-        <style>* {font-family: Courier;}</style>
     </head>
     
     <body>

--- a/assets/standard_test_img/standard_test_img_border.html
+++ b/assets/standard_test_img/standard_test_img_border.html
@@ -6,7 +6,6 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Artem Ascii Image</title>
-        <style>* {font-family: Courier;}</style>
     </head>
     
     <body>

--- a/assets/standard_test_img/standard_test_img_border_outline.html
+++ b/assets/standard_test_img/standard_test_img_border_outline.html
@@ -6,7 +6,6 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Artem Ascii Image</title>
-        <style>* {font-family: Courier;}</style>
     </head>
     
     <body>

--- a/assets/standard_test_img/standard_test_img_outline.html
+++ b/assets/standard_test_img/standard_test_img_outline.html
@@ -6,7 +6,6 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Artem Ascii Image</title>
-        <style>* {font-family: Courier;}</style>
     </head>
     
     <body>

--- a/assets/standard_test_img/standard_test_img_outline_hysteresis.html
+++ b/assets/standard_test_img/standard_test_img_outline_hysteresis.html
@@ -6,7 +6,6 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Artem Ascii Image</title>
-        <style>* {font-family: Courier;}</style>
     </head>
     
     <body>

--- a/src/target/html.rs
+++ b/src/target/html.rs
@@ -1,7 +1,7 @@
 ///Returns the top part of the output html file.
 ///
 /// This contains the html elements needed for a correct html file.
-/// The title will be set to `Artem Ascii Image`, whilst the will be set to `Courier` ( a monospace font)
+/// The title will be set to `Artem Ascii Image`.
 /// It will also have the pre tag for correct spacing/line breaking
 ///
 /// # Examples
@@ -20,7 +20,6 @@ pub fn html_top() -> String {
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Artem Ascii Image</title>
-        <style>* {font-family: Courier;}</style>
     </head>
     
     <body>
@@ -42,7 +41,6 @@ mod test_push_html_top {
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Artem Ascii Image</title>
-        <style>* {font-family: Courier;}</style>
     </head>
     
     <body>

--- a/tests/arguments/output.rs
+++ b/tests/arguments/output.rs
@@ -36,7 +36,7 @@ pub mod output_file {
             .args(["-o", "/tmp/ascii.html"]);
         //only check first line
         cmd.assert().success().stdout(predicate::str::starts_with(
-            "Written 62674 bytes to /tmp/ascii.html",
+            "Written 62625 bytes to /tmp/ascii.html",
         ));
         //delete output file
         fs::remove_file("/tmp/ascii.html").unwrap();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2,6 +2,7 @@ use assert_cmd::prelude::*; // Add methods on commands
 use predicates::prelude::*;
 use std::fs::{self};
 // Used for writing assertions
+use pretty_assertions::assert_str_eq;
 use std::process::Command; // Run programs
 
 #[test]
@@ -113,7 +114,7 @@ fn full_file_compare_html() {
     let desired_output =
         fs::read_to_string("assets/standard_test_img/standard_test_img.html").unwrap(); //ignore errors
     cmd.assert().success().stdout(predicate::str::contains(
-        "Written 62674 bytes to /tmp/ascii.html",
+        "Written 62625 bytes to /tmp/ascii.html",
     ));
 
     let file_output = fs::read_to_string("/tmp/ascii.html").unwrap(); //ignore errors
@@ -121,7 +122,7 @@ fn full_file_compare_html() {
     //delete output file
     fs::remove_file("/tmp/ascii.html").unwrap();
 
-    assert_eq!(desired_output, file_output);
+    assert_str_eq!(desired_output, file_output);
 }
 
 #[test]
@@ -136,7 +137,7 @@ fn full_file_compare_html_border() {
     let desired_output =
         fs::read_to_string("assets/standard_test_img/standard_test_img_border.html").unwrap(); //ignore errors
     cmd.assert().success().stdout(predicate::str::contains(
-        "Written 61712 bytes to /tmp/ascii.html",
+        "Written 61663 bytes to /tmp/ascii.html",
     ));
 
     let file_output = fs::read_to_string("/tmp/ascii.html").unwrap(); //ignore errors
@@ -144,7 +145,7 @@ fn full_file_compare_html_border() {
     //delete output file
     fs::remove_file("/tmp/ascii.html").unwrap();
 
-    assert_eq!(desired_output, file_output);
+    assert_str_eq!(desired_output, file_output);
 }
 
 #[test]
@@ -159,7 +160,7 @@ fn full_file_compare_html_outline() {
     let desired_output =
         fs::read_to_string("assets/standard_test_img/standard_test_img_outline.html").unwrap(); //ignore errors
     cmd.assert().success().stdout(predicate::str::contains(
-        "Written 19834 bytes to /tmp/ascii.html",
+        "Written 19785 bytes to /tmp/ascii.html",
     ));
 
     let file_output = fs::read_to_string("/tmp/ascii.html").unwrap(); //ignore errors
@@ -167,7 +168,7 @@ fn full_file_compare_html_outline() {
     //delete output file
     fs::remove_file("/tmp/ascii.html").unwrap();
 
-    assert_eq!(desired_output, file_output);
+    assert_str_eq!(desired_output, file_output);
 }
 
 #[test]
@@ -182,7 +183,7 @@ fn full_file_compare_html_background_color() {
     let desired_output =
         fs::read_to_string("assets/standard_test_img/standard_test_img_background.html").unwrap(); //ignore errors
     cmd.assert().success().stdout(predicate::str::contains(
-        "Written 100242 bytes to /tmp/ascii.html",
+        "Written 100193 bytes to /tmp/ascii.html",
     ));
 
     let file_output = fs::read_to_string("/tmp/ascii.html").unwrap(); //ignore errors
@@ -190,5 +191,5 @@ fn full_file_compare_html_background_color() {
     //delete output file
     fs::remove_file("/tmp/ascii.html").unwrap();
 
-    assert_eq!(desired_output, file_output);
+    assert_str_eq!(desired_output, file_output);
 }


### PR DESCRIPTION
On Firefox, setting the Courier font family results in a 1.2 line spacing. This
does not look good.
