### PR TITLE
feat: add shell `completion` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.54"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad5b1b4de04fead402672b48897030eec1f3bfe1550776322f59f6d6e6a5677"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ harness = false
 
 [build-dependencies]
 clap = { version = "4.5", features = ["cargo", "derive"] }
-clap_complete = "4.5"
+clap_complete = "4.6"
 clap_mangen = "0.2"
 log = "0.4"
 
@@ -49,6 +49,7 @@ pretty_assertions = "1.4.1"
 image = "0.25.4"
 colored = "3"
 clap = { version = "4.5", features = ["cargo"] }
+clap_complete = "4.6"
 terminal_size = "0.4.0"
 log = "0.4"
 env_logger = "0.11"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{builder::PossibleValue, value_parser, Arg, ArgAction, Command, ValueEnum, ValueHint};
+use clap_complete::Shell;
 
 /// Get arguments from the command line.
 ///
@@ -172,6 +173,17 @@ pub fn build_cli() -> Command {
                 .help("Choose the verbosity of the logging level. Warnings and errors will always be shown by default. To completely disable them, \
                 use the off argument."),
         )
+        .subcommand_negates_reqs(true)
+        .subcommand(
+            Command::new("completion")
+                .about("Generate shell completions for the specified shell")
+                .arg(
+                    Arg::new("shell")
+                        .required(true)
+                        .value_parser(value_parser!(Shell))
+                        .help("The shell to generate completions for"),
+                ),
+        )
 }
 /// Verbosity enum for different logging levels.
 ///
@@ -316,6 +328,38 @@ mod test {
             "--no-color",
             "--backgrounds",
         ]);
+        assert!(matches.is_err());
+    }
+
+    #[test]
+    fn completion_subcommand_valid_shell() {
+        let matches = build_cli().try_get_matches_from(["artem", "completion", "bash"]);
+        assert!(matches.is_ok());
+        let matches = matches.unwrap();
+        let sub = matches.subcommand_matches("completion").unwrap();
+        assert_eq!(*sub.get_one::<Shell>("shell").unwrap(), Shell::Bash);
+    }
+
+    #[test]
+    fn completion_subcommand_all_shells() {
+        for shell in ["bash", "elvish", "fish", "powershell", "zsh"] {
+            let matches = build_cli().try_get_matches_from(["artem", "completion", shell]);
+            assert!(
+                matches.is_ok(),
+                "completion subcommand should accept {shell}"
+            );
+        }
+    }
+
+    #[test]
+    fn completion_subcommand_missing_shell() {
+        let matches = build_cli().try_get_matches_from(["artem", "completion"]);
+        assert!(matches.is_err());
+    }
+
+    #[test]
+    fn completion_subcommand_invalid_shell() {
+        let matches = build_cli().try_get_matches_from(["artem", "completion", "invalid"]);
         assert!(matches.is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,20 @@ fn main() {
     // get args from cli
     let matches = cli::build_cli().get_matches();
 
+    // handle the completion subcommand before any other processing
+    if let Some(sub_matches) = matches.subcommand_matches("completion") {
+        let shell = *sub_matches
+            .get_one::<clap_complete::Shell>("shell")
+            .expect("shell argument is required");
+        clap_complete::generate(
+            shell,
+            &mut cli::build_cli(),
+            clap::crate_name!(),
+            &mut std::io::stdout(),
+        );
+        return;
+    }
+
     // get log level from args
     // enable logging
     env_logger::builder()


### PR DESCRIPTION
Adds a `completion` subcommand using `clap_complete` that generates shell completions at runtime for all supported shells (bash, elvish, fish, powershell, zsh).

Usage: `artem completion <shell>`

Changes:
- Add `clap_complete` as a runtime dependency
- Add `completion` subcommand to CLI with `subcommand_negates_reqs(true)`
  so the required INPUT argument is waived
- Handle `completion` subcommand in main.rs, generating completions to stdout
- Add unit tests for valid/invalid and missing shell argument

Co-authored-by: Copilot <copilot@github.com>